### PR TITLE
Add completion for packages in update subcommand

### DIFF
--- a/share/completions/composer.fish
+++ b/share/completions/composer.fish
@@ -20,11 +20,25 @@ function __fish_composer_using_command
   return 1
 end
 
+function __fish_composer_packages
+    echo "
+import json
+json_data = open('composer.json')
+data = json.load(json_data)
+json_data.close()
+packages = data['require'].keys() + data['require-dev'].keys()
+print \"\n\".join(packages)
+      " | python
+end
+
 #add cmds list
 set --local composer_cmds 'about' 'archive' 'browse' 'clear-cache' 'clearcache' 'config' 'create-project' 'depends' 'diagnose' 'dump-autoload' 'dumpautoload' 'global' 'help' 'home' 'init' 'install' 'licenses' 'list' 'remove' 'require' 'run-script' 'search' 'self-update' 'selfupdate' 'show' 'status' 'update' 'validate'
 
 #help
 complete -f -c composer -n '__fish_composer_using_command help' -a "$composer_cmds"
+
+#update
+complete -f -c composer -n '__fish_composer_using_command update' -a "(__fish_composer_packages)"
 
 #popisky
 complete -f -c composer -n '__fish_composer_needs_command' -a 'about' -d 'Short information about Composer'


### PR DESCRIPTION
## Description

This patch adds completion for the update subcommand, that is, when the user types in `composer update <tab>`.

The code depends on python for the json parsing.  I'm not sure if this is appropriate or if there is a fish-native way to parse json data.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
